### PR TITLE
Use "malloc" to allocate _value, instead of "new".

### DIFF
--- a/src/my92xx.cpp
+++ b/src/my92xx.cpp
@@ -199,7 +199,7 @@ my92xx::my92xx(my92xx_model_t model, unsigned char chips, unsigned char di, unsi
     } else if (_model == MY92XX_MODEL_MY9231) {
         _channels = 3 * _chips;
     }
-    _value = new uint16_t(_channels);
+    _value = (uint16_t*) malloc (sizeof(uint16_t) * _channels);
     for (unsigned char i=0; i<_channels; i++) {
         _value[i] = 0;
     }


### PR DESCRIPTION
The "new" operator is mapped to malloc() in the AVR core for Arduino, but not in the ESP8266 core. "new" on primitive types interferes with the umm_malloc memory manager, which will then cause crashes on later dynamic allocations using umm_malloc.

In the AVR core, there's a file new.cpp, where the "new" operator for primitives gets mapped to malloc(), so everything is fine there.

In the ESP8266, the "new" operator isn't overridden. Thus, it interferes with the heap management done by umm_malloc() and causes weird crashes during later calls to malloc().

Using malloc() here is functionally equivalent and works on both AVR and ESP8266.